### PR TITLE
 Fix inheritance of BasedOnStyles

### DIFF
--- a/config/builder.nix
+++ b/config/builder.nix
@@ -11,11 +11,11 @@
   stringList = concatStringsSep ", ";
   makeFormatOption = options: let
     rest = removeAttrs options ["basedOnStyles"];
+    optionalBasedOnStyles = lib.optionalAttrs (options ? basedOnStyles) {
+      BasedOnStyles = stringList options.basedOnStyles;
+    };
   in
-    {
-      BasedOnStyles = stringList options.basedOnStyles or [];
-    }
-    // rest;
+    optionalBasedOnStyles // rest;
 in
   {
     minAlertLevel ? "warning",


### PR DESCRIPTION
Currently, not explicitly providing a basedOnStyles option results in an empty BasedOnStyles. This is not the expected behavior: if a basedOnStyles section is not defined, do not include it (causing it to be inherited).